### PR TITLE
bugfix: on osx/linux the environment variable is just called "USER"

### DIFF
--- a/app/sum-backend-helpers.js
+++ b/app/sum-backend-helpers.js
@@ -163,7 +163,7 @@ define('sum-backend-helpers', Class.extend({
      */
     getUsername: function() {
         if (typeof config.username == "undefined")
-            return process.env.USERNAME.toLowerCase();
+            return (process.env.USER || process.env.USERNAME).toLowerCase();
         else
             return config.username.toLowerCase();
     },


### PR DESCRIPTION
As it's stated in the title ... username cannot be resolved from environment currently when in linux or mac os x. This pull requested fixes the problem.
